### PR TITLE
Workaround to stop turbo links breaking redirect to stripe

### DIFF
--- a/app/views/account/index.html.erb
+++ b/app/views/account/index.html.erb
@@ -10,7 +10,7 @@
           Billing Status: <%= red_green_message(current_user.paying_customer?, 'Active', 'Inactive') %><br>
         </div>
         <div class="flex-shrink">
-          <%= link_to 'Manage >>', billing_portal_path, class: "font-medium text-indigo-500" %>
+          <%= link_to 'Manage >>', billing_portal_path, data: { turbo: false }, class: "font-medium text-indigo-500" %>
         </div>
       </div>
 


### PR DESCRIPTION
This implements a workaround to the issue described here: https://github.com/hotwired/turbo/issues/203